### PR TITLE
Handle path joining more robustly

### DIFF
--- a/Modular.R
+++ b/Modular.R
@@ -113,6 +113,10 @@ if("mzR" %in% rownames(installed.packages()) == FALSE)  {
   BiocManager::install("mzR")}
 library(mzR)
 
+#define function to concatenate file paths and files together without issues due to presence of trailing slash in file path.
+file.join = function(..., sep = .Platform$file.sep){
+    gsub("//", "/", file.path(..., sep = sep))
+}
 
 if (ManuallyInputVariables==TRUE){
   
@@ -169,7 +173,7 @@ if (ManuallyInputVariables==TRUE){
   ####################### Get input from csv VARIABLES SECTION ###############################
   #parametersDirectory
   parametersDir <- "C:/NEW_SOFTWARE/2023_24_UPDATES_FM_LM/RapidTest/"
-  parametersFile <- paste(parametersDir, "PARAMETERS.csv", sep="")
+  parametersFile <- file.join(parametersDir, "PARAMETERS.csv")
   parametersInput_csv <- read.csv(parametersFile, sep=",", na.strings="NA", dec=".", strip.white=TRUE,header=FALSE)
   parametersInput_csv <- as.matrix(parametersInput_csv)
   ErrorOutput<-0


### PR DESCRIPTION
Define file.join function for joining file paths and file names together. The new function is necessary to handle file paths regardeless of whether they have a trailing slash.