### PR TITLE
Detect core count more reliably and leverage all of them on HPC

### DIFF
--- a/Modular.R
+++ b/Modular.R
@@ -14,6 +14,7 @@ csvInput <- TRUE
 ManuallyInputVariables <- FALSE
 RT_flagging <- TRUE #JPK: for PFAS analysis
 ParallelComputing <- TRUE
+HPC <- FALSE
 Lipid <- FALSE
 TWeen_pos <- FALSE #PJS: for PolyMatch
 FilterAbovePrecursor <- 1 #how far from the precursor should fragment masses be kept (e.g. if precursor is 700, should 702 be considered?)
@@ -43,9 +44,13 @@ if (ParallelComputing == TRUE) {
   library(foreach)
   if("doParallel" %in% rownames(installed.packages()) == FALSE) {install.packages("doParallel", repos = "http://cran.us.r-project.org")}
   library(doParallel)
-  DC <- as.numeric(detectCores())
+  library(parallelly)
+  DC <- as.numeric(availableCores())
   if (is.na(DC)) {
     DC <- makePSOCKcluster(4)
+    registerDoParallel(DC)
+  } else if (HPC == TRUE) {
+    DC <- makePSOCKcluster(DC)
     registerDoParallel(DC)
   } else if (DC <= 4) {
     DC <- makePSOCKcluster(DC)


### PR DESCRIPTION
detectCores() returns the number of CPU cores installed on a computer, not the number of cores that are available to be used by the running processes. On HPC clusters, the available cores are often restricted by linux control groups to some lesser number than the total installed on the system. availableCores() is control group aware and will return the correct number on HPC clusters as well as other systems.

Create variable HPC with default value FALSE for determining if running on HPC system.

On HPC systems, set the makePSOCKcluster size to the number of cores, reserving no additional cores. Reserving additional cores for system stability is unnessesary within an HPC environment.